### PR TITLE
Elite (#3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,28 +26,27 @@ It will download the last version of every file present on Wayback Machine to `.
 
 ## Advanced Usage
 
-    Usage: wayback_machine_downloader http://example.com
+	Usage: wayback_machine_downloader http://example.com
 
-    Download an entire website from the Wayback Machine.
+	Download an entire website from the Wayback Machine.
 
-    Optional options:
-        -d, --directory PATH             Directory to save the downloaded files into
-                        		         Default is ./websites/ plus the domain name
-        -f, --from TIMESTAMP             Only files on or after timestamp supplied (ie. 20060716231334)
-        -t, --to TIMESTAMP               Only files on or before timestamp supplied (ie. 20100916231334)
-        -o, --only ONLY_FILTER           Restrict downloading to urls that match this filter
-		                                 (use // notation for the filter to be treated as a regex)
-        -x, --exclude EXCLUDE_FILTER     Skip downloading of urls that match this filter
-        				                 (use // notation for the filter to be treated as a regex)
-        -a, --all                        Expand downloading to error files (40x and 50x) and redirections (30x)
-        -c, --concurrency NUMBER         Number of multiple files to dowload at a time
-                        		         Default is one file at a time (ie. 20)
-        -p, --snapshot-pages NUMBER      Maximum snapshot pages to consider (Default is 100)
-                			             Count an average of 150,000 snapshots per page 
-        -l, --list                       Only list file urls in a JSON format with the archived timestamps, won't download anything.
-        -v, --version                    Display version
-
-
+	Optional options:
+	    -d, --directory PATH             Directory to save the downloaded files into
+					     Default is ./websites/ plus the domain name
+	    -s, --all-timestamps             Download all snapshots/timestamps for a given website
+	    -f, --from TIMESTAMP             Only files on or after timestamp supplied (ie. 20060716231334)
+	    -t, --to TIMESTAMP               Only files on or before timestamp supplied (ie. 20100916231334)
+	    -e, --exact-url                  Download only the url provied and not the full site
+	    -o, --only ONLY_FILTER           Restrict downloading to urls that match this filter
+					     (use // notation for the filter to be treated as a regex)
+	    -x, --exclude EXCLUDE_FILTER     Skip downloading of urls that match this filter
+					     (use // notation for the filter to be treated as a regex)
+	    -a, --all                        Expand downloading to error files (40x and 50x) and redirections (30x)
+	    -c, --concurrency NUMBER         Number of multiple files to dowload at a time
+					     Default is one file at a time (ie. 20)
+	    -p, --maximum-snapshot NUMBER    Maximum snapshot pages to consider (Default is 100)
+					     Count an average of 150,000 snapshots per page
+	    -l, --list                       Only list file urls in a JSON format with the archived timestamps, won't download anything
 	    
 ## Specify directory to save files to
 
@@ -58,6 +57,22 @@ Optional. By default, Wayback Machine Downloader will download files to `./websi
 Example:
 
     wayback_machine_downloader http://example.com --directory downloaded-backup/
+    
+## All Timestamps
+
+    -s, --all-timestamps 
+
+Optional. This option will download all timestamps/snapshots for a given website. It will uses the timepstamp of each snapshot as directory.
+
+Example:
+
+    wayback_machine_downloader http://example.com --all-timestamps 
+    
+    Will download:
+    	websites/example.com/20060715085250/index.html
+    	websites/example.com/20051120005053/index.html
+    	websites/example.com/20060111095815/img/logo.png
+    	...
 
 ## From Timestamp
 
@@ -80,6 +95,17 @@ Wayback Machine Downloader will then fetch only file versions on or before the t
 Example:
 
     wayback_machine_downloader http://example.com --to 20100916231334
+    
+## Exact Url
+
+	-e, --exact-url 
+
+Optional. If you want to retrieve only the file matching exactly the url provided, you can use this flag. It will avoid downloading anything else.
+
+For example, if you only want to download only the html homepage file of example.com:
+
+    wayback_machine_downloader http://example.com --exact-url 
+
 
 ## Only URL Filter
 
@@ -167,11 +193,3 @@ To run the tests:
 
     bundle install
     bundle exec rake test
-
-## Donation
-
-Wayback Machine Downloader is free and open source.
-
-If you want to donate: [![Gratipay Team](https://img.shields.io/gratipay/team/hartator.svg)](https://gratipay.com/hartator/)
-
-You can also donate to the Archive.org: https://archive.org/donate/

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-time-machine

--- a/bin/wayback_machine_downloader
+++ b/bin/wayback_machine_downloader
@@ -14,10 +14,14 @@ option_parser = OptionParser.new do |opts|
   opts.separator ""
   opts.separator "Optional options:"
 
-  opts.on("-d", "--directory PATH", String, "Directory to save the downloaded files into\n\t\t\t\t     Default is ./websites/ plus the domain name") do |t|
+  opts.on("-d", "--directory PATH", String, "Directory to save the downloaded files into", "Default is ./websites/ plus the domain name") do |t|
     options[:directory] = t
   end
 
+  opts.on("-s", "--all-timestamps", "Download all snapshots/timestamps for a given website") do |t|
+    options[:all_timestamps] = true
+  end
+  
   opts.on("-f", "--from TIMESTAMP", Integer, "Only files on or after timestamp supplied (ie. 20060716231334)") do |t|
     options[:from_timestamp] = t
   end
@@ -26,11 +30,15 @@ option_parser = OptionParser.new do |opts|
     options[:to_timestamp] = t
   end
 
-  opts.on("-o", "--only ONLY_FILTER", String, "Restrict downloading to urls that match this filter\n\t\t\t\t     (use // notation for the filter to be treated as a regex)") do |t|
+  opts.on("-e", "--exact-url", "Download only the url provied and not the full site") do |t|
+    options[:exact_url] = t
+  end
+
+  opts.on("-o", "--only ONLY_FILTER", String, "Restrict downloading to urls that match this filter", "(use // notation for the filter to be treated as a regex)") do |t|
     options[:only_filter] = t
   end
 
-  opts.on("-x", "--exclude EXCLUDE_FILTER", String, "Skip downloading of urls that match this filter\n\t\t\t\t     (use // notation for the filter to be treated as a regex)") do |t|
+  opts.on("-x", "--exclude EXCLUDE_FILTER", String, "Skip downloading of urls that match this filter", "(use // notation for the filter to be treated as a regex)") do |t|
     options[:exclude_filter] = t
   end
 
@@ -38,15 +46,15 @@ option_parser = OptionParser.new do |opts|
     options[:all] = true
   end
 
-  opts.on("-c", "--concurrency NUMBER", Integer, "Number of multiple files to dowload at a time\n\t\t\t\t     Default is one file at a time (ie. 20)") do |t|
+  opts.on("-c", "--concurrency NUMBER", Integer, "Number of multiple files to dowload at a time", "Default is one file at a time (ie. 20)") do |t|
     options[:threads_count] = t
   end
 
-  opts.on("-p", "--maximum-snapshot NUMBER", Integer, "Maximum snapshot pages to consider (Default is 100)\n\t\t\t\t     Count an average of 150,000 snapshots per page ") do |t|
+  opts.on("-p", "--maximum-snapshot NUMBER", Integer, "Maximum snapshot pages to consider (Default is 100)", "Count an average of 150,000 snapshots per page") do |t|
     options[:maximum_pages] = t
   end
 
-  opts.on("-l", "--list", "Only list file urls in a JSON format with the archived timestamps, won't download anything.") do |t|
+  opts.on("-l", "--list", "Only list file urls in a JSON format with the archived timestamps, won't download anything") do |t|
     options[:list] = true
   end
 
@@ -58,7 +66,7 @@ end.parse!
 if (base_url = ARGV[-1])
   options[:base_url] = base_url
   wayback_machine_downloader = WaybackMachineDownloader.new options
-  if wayback_machine_downloader.list
+  if options[:list]
     wayback_machine_downloader.list_files
   else
     wayback_machine_downloader.download_files

--- a/lib/wayback_machine_downloader/archive_api.rb
+++ b/lib/wayback_machine_downloader/archive_api.rb
@@ -1,15 +1,15 @@
 module ArchiveAPI
 
-	def get_raw_list_from_api url, page_index
-		request_url = "http://web.archive.org/cdx/search/xd?url="
-		request_url += url
-		request_url += parameters_for_api page_index
+  def get_raw_list_from_api url, page_index
+    request_url = "http://web.archive.org/cdx/search/xd?url="
+    request_url += url
+    request_url += parameters_for_api page_index
 
     open(request_url).read
-	end
+  end
 
-	def parameters_for_api page_index
-		parameters = "&fl=timestamp,original&collapse=digest&gzip=false"
+  def parameters_for_api page_index
+    parameters = "&fl=timestamp,original&collapse=digest&gzip=false"
     if @all
       parameters += ""
     else

--- a/lib/wayback_machine_downloader/tidy_bytes.rb
+++ b/lib/wayback_machine_downloader/tidy_bytes.rb
@@ -60,7 +60,7 @@ module TibyBytes
       bytes.each_index do |i|
 
         byte          = bytes[i]
-        is_ascii      = byte < 128
+        _is_ascii     = byte < 128
         is_cont       = byte > 127 && byte < 192
         is_lead       = byte > 191 && byte < 245
         is_unused     = byte > 240
@@ -78,7 +78,7 @@ module TibyBytes
             # the leading byte.
             begin
               (1..(i - last_lead)).each {|j| bytes[i - j] = tidy_byte(bytes[i - j])}
-            rescue NoMethodError => e
+            rescue NoMethodError
               next
             end
             conts_expected = 0
@@ -98,7 +98,7 @@ module TibyBytes
       end
       begin
         bytes.empty? ? nil : bytes.flatten.compact.pack("C*").unpack("U*").pack("U*")
-      rescue ArgumentError => e
+      rescue ArgumentError
         nil
       end
     end

--- a/lib/wayback_machine_downloader/to_regex.rb
+++ b/lib/wayback_machine_downloader/to_regex.rb
@@ -25,7 +25,7 @@ module ToRegex
     # @option options [true,false] :lang /foo/[nesu]
     def to_regex(options = {})
       if args = as_regexp(options)
-        ::Regexp.new *args
+        ::Regexp.new(*args)
       end
     end
 

--- a/test/test_wayback_machine_downloader.rb
+++ b/test/test_wayback_machine_downloader.rb
@@ -4,7 +4,8 @@ require 'wayback_machine_downloader'
 class WaybackMachineDownloaderTest < Minitest::Test
 
   def setup
-    @wayback_machine_downloader = WaybackMachineDownloader.new base_url: 'http://www.onlyfreegames.net'
+    @wayback_machine_downloader = WaybackMachineDownloader.new(
+      base_url: 'http://www.onlyfreegames.net')
     $stdout = StringIO.new
   end
 
@@ -36,6 +37,16 @@ class WaybackMachineDownloaderTest < Minitest::Test
       file_id: "strat.html"
     }
     assert_equal file_expected, @wayback_machine_downloader.get_file_list_by_timestamp[-2]
+  end
+
+  def test_without_exact_url
+    @wayback_machine_downloader.exact_url = false
+    assert @wayback_machine_downloader.get_file_list_curated.size > 1
+  end
+
+  def test_exact_url
+    @wayback_machine_downloader.exact_url = true
+    assert_equal 1, @wayback_machine_downloader.get_file_list_curated.size
   end
 
   def test_file_list_only_filter_without_matches
@@ -74,6 +85,11 @@ class WaybackMachineDownloaderTest < Minitest::Test
     assert_includes linux_page.read, "Linux Games"
   end
 
+  def test_all_timestamps_being_respected
+    @wayback_machine_downloader.all_timestamps = true
+    assert_equal 68, @wayback_machine_downloader.get_file_list_curated.size
+  end
+
   def test_from_timestamp_being_respected
     @wayback_machine_downloader.from_timestamp = 20050716231334
     file_url = @wayback_machine_downloader.get_file_list_curated["linux.htm"][:file_url]
@@ -85,9 +101,25 @@ class WaybackMachineDownloaderTest < Minitest::Test
     assert_nil @wayback_machine_downloader.get_file_list_curated["linux.htm"]
   end
 
-  def test_file_list_exclude_filter_with_a_regex
+  def test_all_get_file_list_curated_size
     @wayback_machine_downloader.all = true
     assert_equal 69, @wayback_machine_downloader.get_file_list_curated.size
+  end
+ 
+  # Testing encoding conflicts needs a different base_url
+  def test_nonascii_suburls_download
+    @wayback_machine_downloader = WaybackMachineDownloader.new(
+      base_url: 'https://en.wikipedia.org/wiki/%C3%84')
+    # Once just for the downloading...
+    @wayback_machine_downloader.download_files
+  end
+
+  def test_nonascii_suburls_already_present
+    @wayback_machine_downloader = WaybackMachineDownloader.new(
+      base_url: 'https://en.wikipedia.org/wiki/%C3%84')
+    # ... twice to test the "is already present" case
+    @wayback_machine_downloader.download_files
+    @wayback_machine_downloader.download_files
   end
 
 end


### PR DESCRIPTION
* Update wayback_machine_downloader

* Update wayback_machine_downloader.rb

* Added prospective test for encoding conflict errors

* Split encoding test into two tests

(One for downloading, one for when files are already present)

* Alters encoding of file_url to fix encoding incompatibilities

* Add explicit variable current encoding

* Bump Gem version

* Fix whitespace

* Shorten some lines for readability

* Remove list attribute from the downloader.

Whether to list or download is a program option external to the downloader

* Avoid interleaving status output with file listing.

Before:

[
Getting snapshot pages.. found 1 snaphots to consider.

{"file_url":"http://www.trackpedia.com:80/forums/archive/index.php/f-115.html","timestamp":20131221124252,"file_id":"forums/archive/index.php/f-115.html"},
]

After:

Getting snapshot pages.. found 1 snaphots to consider.

[
{"file_url":"http://www.trackpedia.com:80/forums/archive/index.php/f-115.html","timestamp":20131221124252,"file_id":"forums/archive/index.php/f-115.html"},
]

* Add exact_match option.

With this option set, Wayback Machine Downloader
will only look for snapshots matching the exact base_url
passed in rather than base_url and its children.

This is useful when trying to download a single file
rather than mirroring a site.

* File.exists? causes warning is ruby 2.4.1, use exist?

* Fix test name so that it does not shadow another test

* Parens are required before * when used for splatting.

https://stackoverflow.com/questions/41821628/ruby-how-can-i-kill-warning-interpreted-as-argument-prefix

* Get rid of assigned but unused variable warnings under ruby 2.4

* Line length

* Fix exact match logic and add a test

* fixed bad characters in directories for windows

* Left align correctly multiline help description text

* Bump Gem version

* Remove donation bit for the Readme

* Fix row align for GitHub repository preview

* Fix length of arguments per line

* Remove too verbose comment

* Replace exact match by exact url

* Add explanation to use exact url flag for the CLI

* Add explanations to use exact url flag to Readme

* Bump Gem version

* Fix issues with CLI option not setting exact_url option right

* Bump Gem version

* Fix Readme errors on flag name

* Test `all_timestamps` option download all timestamps

* Use more explicit variable name `all_timestamps`

* Give more details about what the option `--all-timestamps` do

* Fix missing comma issue

* Bump Gem version

* Explain `all-timestamps` option

* Fix typo and formatting

* Bump Gem version

* Set theme jekyll-theme-time-machine